### PR TITLE
Match 7 items with rar

### DIFF
--- a/app/kod/archiveLib/kodRarArchive.class.php
+++ b/app/kod/archiveLib/kodRarArchive.class.php
@@ -161,7 +161,7 @@ class kodRarArchive {
 		$reg = '/\s*([-\.\w]+)\s+(\d+)\s+(\d+)\s+\d+%\s+(\d{2,4}-\d{2}-\d{2} \d{2}:\d{2})\s+\w+\s+(.*)\n/i';
 		preg_match_all($reg,$match[1]."\n",$matchItem);
 		if( !is_array($matchItem) || 
-			count($matchItem) != 6 ||
+			count($matchItem) != 7 ||
 			count($matchItem[0]) == 0
 			){
 			return array('code'=>false,'data'=>'Match Nothing Item!');


### PR DESCRIPTION
On my system

`app/kod/archiveLib/bin/rar v /path/to/file.rar`

Outputs:
```
UNRAR 5.40 freeware      Copyright (c) 1993-2016 Alexander Roshal

Archive: /path/to/file.rar
Details: RAR 4, volume

 Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
----------- ---------  -------- ----- ---------- -----  --------  ----
 -rw-rw-r-- 12344567  11344567  -->  2019-03-25 02:02  1AA24184  file
----------- ---------  -------- ----- ---------- -----  --------  ----
            12344567  11344567   9%  volume 1                    1
```
```php
preg_match_all('/\s*([-\.\w]+)\s+(\d+)\s+(\d+)\s+(\d+%|-+>)\s+(\d{2,4}-\d{2}-\d{2} \d{2}:\d{2})\s+\w+\s+(.*)\n/i', $input_lines, $output_array);
```
with the above included fix from #350, `preg_match_all` matches 7 items (and will without #350):
```
0	=>	
 -rw-rw-r-- 12344567  11344567  -->  2019-03-25 02:02  1AA24184  file
1	=>	-rw-rw-r--
2	=>	12344567
3	=>	11344567
4	=>	-->
5	=>	2019-03-25 02:02
6	=>	file
```