### PR TITLE
Match rar when --> instead of %

### DIFF
--- a/app/kod/archiveLib/kodRarArchive.class.php
+++ b/app/kod/archiveLib/kodRarArchive.class.php
@@ -158,7 +158,7 @@ class kodRarArchive {
 
 		//windows  :...D...   93691   82633  88%  2016-12-09 02:20  396CC62C  000/a/32486963.png
 		//linux:   :-rwxr-xr-x   93691   82643  88%  2016-12-09 02:20  396CC62C  000/a/32486963.png
-		$reg = '/\s*([-\.\w]+)\s+(\d+)\s+(\d+)\s+\d+%\s+(\d{2,4}-\d{2}-\d{2} \d{2}:\d{2})\s+\w+\s+(.*)\n/i';
+		$reg = '/\s*([-\.\w]+)\s+(\d+)\s+(\d+)\s+\d+%|-+>\s+(\d{2,4}-\d{2}-\d{2} \d{2}:\d{2})\s+\w+\s+(.*)\n/i';
 		preg_match_all($reg,$match[1]."\n",$matchItem);
 		if( !is_array($matchItem) || 
 			count($matchItem) != 6 ||


### PR DESCRIPTION
On my system

`app/kod/archiveLib/bin/rar v /path/to/file.rar`

Outputs:
```
UNRAR 5.40 freeware      Copyright (c) 1993-2016 Alexander Roshal

Archive: /path/to/file.rar
Details: RAR 4, volume

 Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
----------- ---------  -------- ----- ---------- -----  --------  ----
 -rw-rw-r-- 12344567  11344567  -->  2019-03-25 02:02  1AA24184  file
----------- ---------  -------- ----- ---------- -----  --------  ----
            12344567  11344567   9%  volume 1                    1
```
This is when the archive is a multi-part archive. Therefore we need to adjust the regex slightly to include this case.