### PR TITLE
将文件与目录的创建权限进行区分，文件为640，目录为750

### DIFF
--- a/app/controller/explorer.class.php
+++ b/app/controller/explorer.class.php
@@ -184,8 +184,8 @@ class explorer extends Controller{
 			}
 		}
 		Hook::trigger("explorer.mkdirBefore",$path);
-		if(mk_dir($path,DEFAULT_PERRMISSIONS)){
-			chmod_path($path,DEFAULT_PERRMISSIONS);
+		if(mk_dir($path,DEFAULT_DIR_PERRMISSIONS)){
+			chmod_path($path,DEFAULT_DIR_PERRMISSIONS);
 			Hook::trigger("explorer.mkdirAfter",$path);
 			return true;
 		}

--- a/config/config.php
+++ b/config/config.php
@@ -38,7 +38,8 @@ define('FUNCTION_DIR',	LIB_DIR .'function/');		//函数库目录
 define('CLASS_DIR',		LIB_DIR .'kod/');			//工具类目录
 define('CORER_DIR',		LIB_DIR .'core/');			//核心目录
 define('SDK_DIR',		LIB_DIR .'sdks/');			//
-define('DEFAULT_PERRMISSIONS',0755);	//新建文件、解压文件默认权限，777 部分虚拟主机限制了777
+define('DEFAULT_PERRMISSIONS',0640);	//新建文件、解压文件默认权限
+define('DEFAULT_DIR_PERRMISSIONS',0750);//新建目录
 
 /*
  * 可以数据目录;移到web目录之外，可以使程序更安全, 就不用限制用户的扩展名权限了;

--- a/config/define.php
+++ b/config/define.php
@@ -1,0 +1,1 @@
+<?php define ('DATA_PATH', '/opt/kodexplorer-data/');


### PR DESCRIPTION
为了提升安全性，不建议使用 777 这样的权限。对于文件，最好使用 640，对于目录，使用 750。
请忽略 define.php 文件。