### PR TITLE
开启httpSendFile后，不能打开文件的bug

### DIFF
--- a/app/function/file.function.php
+++ b/app/function/file.function.php
@@ -1041,14 +1041,19 @@ function file_put_out($file,$download=-1,$downFilename=false){
 	//调用webserver下载
 	$server = strtolower($_SERVER['SERVER_SOFTWARE']);
 	if($server && $GLOBALS['config']['settings']['httpSendFile']){
-		if(strstr($server,'nginx')){//nginx
-			header("X-Sendfile: ".$file);
-		}else if(strstr($server,'apache')){ //apache
-			header('X-Accel-Redirect: '.$file);
-		}else if(strstr($server,'http')){//light http
-			header( "X-LIGHTTPD-send-file: " . $file);
+		if(substr($file, 0, strlen(DATA_PATH)) == DATA_PATH){
+			$relativePath = substr($file,strlen(dirname(DATA_PATH)));
+			if(strstr($server,'nginx')){//nginx
+				header('X-Accel-Redirect:'.$relativePath);
+				return;
+			}else if(strstr($server,'apache')){ //apache
+				header('X-Sendfile:'.$relativePath);
+				return;
+			}else if(strstr($server,'http')){//light http
+				header( "X-LIGHTTPD-send-file: " . $relativePath);
+				return;
+			}
 		}
-		return;
 	}
 	
 	//远程路径不支持断点续传；打开zip内部文件


### PR DESCRIPTION
# 开启httpSendFile后，不能打开文件的bug

1. `nginx`和`apache`的`header`写反了。
2. 这里`header`后面要写`相对地址`，不能用`绝对地址`。
3. 还有`return` 应该是`$server`匹配上,`nginx`，`apache`，`light http`才能`return`。

