### PR TITLE
修复新版PHP中 插件无法更新 无法加载问题

### DIFF
--- a/app/function/common.function.php
+++ b/app/function/common.function.php
@@ -1028,7 +1028,7 @@ function des_encode($key, $text){
 	return base64_encode($encrypted);
 } 
 function pkcs5_unpad($text){
-	$pad = ord($text{strlen($text)-1});
+	$pad = ord($text[strlen($text)-1]);
 	if ($pad > strlen($text)) return $text;
 	if (strspn($text, chr($pad), strlen($text) - $pad) != $pad) return $text;
 	return substr($text, 0, -1 * $pad);


### PR DESCRIPTION
PHP：Deprecated: Array and string offset access syntax with curly braces is deprecated
体现在插件中心无法更新插件 永中office无法使用问题 
看到论坛有人反馈的问题 http://bbs.kodcloud.com/d/418