### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/app/controller/app.class.php
+++ b/app/controller/app.class.php
@@ -119,7 +119,7 @@ class app extends Controller{
 
 	public function getUrlTitle(){
 		$html = curl_get_contents($this->in['url']);
-		$result = match($html,"<title>(.*)<\/title>");
+		$result = matching($html,"<title>(.*)<\/title>");
 		if (strlen($result)>50) {
 			$result = mb_substr($result,0,50,'utf-8');
 		}

--- a/app/function/common.function.php
+++ b/app/function/common.function.php
@@ -759,7 +759,7 @@ function html2txt($document){
 } 
 
 // 获取内容第一条
-function match($content, $preg){
+function matching($content, $preg){
 	$preg = "/" . $preg . "/isU";
 	preg_match($preg, $content, $result);
 	return $result[1];
@@ -837,7 +837,7 @@ function get_utf8_str($string, $length, $dot = '...'){
  * @param string $suffix 截断显示字符
  * @return string 
  */
-function msubstr($str, $start = 0, $length, $charset = "utf-8", $suffix = true){
+function msubstr($str, $start = 0, $length = 0, $charset = "utf-8", $suffix = true){
 	if (function_exists("mb_substr")) {
 		$i_str_len = mb_strlen($str);
 		$s_sub_str = mb_substr($str, $start, $length, $charset);
@@ -1028,7 +1028,7 @@ function des_encode($key, $text){
 	return base64_encode($encrypted);
 } 
 function pkcs5_unpad($text){
-	$pad = ord($text{strlen($text)-1});
+	$pad = ord($text[strlen($text)-1]);
 	if ($pad > strlen($text)) return $text;
 	if (strspn($text, chr($pad), strlen($text) - $pad) != $pad) return $text;
 	return substr($text, 0, -1 * $pad);

--- a/app/function/helper.function.php
+++ b/app/function/helper.function.php
@@ -275,7 +275,7 @@ function php_env_check(){
 function check_cache(){
 	//检查是否更新失效
 	$content = file_get_contents(BASIC_PATH.'config/version.php');
-	$result  = match($content,"'KOD_VERSION','(.*)'");
+	$result  = matching($content,"'KOD_VERSION','(.*)'");
 	if($result != KOD_VERSION){
 		show_tips("您服务器开启了php缓存,文件更新尚未生效;
 			请关闭缓存，或稍后1分钟刷新页面再试！

--- a/app/sdks/MyCaptcha.class.php
+++ b/app/sdks/MyCaptcha.class.php
@@ -30,12 +30,12 @@ class MyCaptcha{
 			for($i=0;$i<$fontfile_width && $symbol<$alphabet_length;$i++){
 				$transparent = (imagecolorat($font, $i, 0) >> 24) == 127;
 				if(!$reading_symbol && !$transparent){
-					$font_metrics[$alphabet{$symbol}]=array('start'=>$i);
+					$font_metrics[$alphabet[$symbol]]=array('start'=>$i);
 					$reading_symbol=true;
 					continue;
 				}
 				if($reading_symbol && $transparent){
-					$font_metrics[$alphabet{$symbol}]['end']=$i;
+					$font_metrics[$alphabet[$symbol]]['end']=$i;
 					$reading_symbol=false;
 					$symbol++;
 					continue;
@@ -51,7 +51,7 @@ class MyCaptcha{
 			$odd=mt_rand(0,1);
 			if($odd==0) $odd=-1;
 			for($i=0;$i<$length;$i++){
-				$m=$font_metrics[$this->keystring{$i}];
+				$m=$font_metrics[$this->keystring[$i]];
 
 				$y=(($i%2)*$fluctuation_amplitude - $fluctuation_amplitude/2)*$odd
 					+ mt_rand(-round($fluctuation_amplitude/3), round($fluctuation_amplitude/3))
@@ -149,7 +149,7 @@ class MyCaptcha{
 		while(true){
 			$str = '';
 			for($i=0;$i<$length;$i++){
-				$str .= $allowed_symbols{mt_rand(0,strlen($allowed_symbols)-1)};
+				$str .= $allowed_symbols[mt_rand(0,strlen($allowed_symbols)-1)];
 			}
 			if(!preg_match('/cp|cb|ck|c6|c9|rn|rm|mm|co|do|cl|db|qp|qb|dp|ww/',$str)) break;
 		}

--- a/app/sdks/lessc.class.php
+++ b/app/sdks/lessc.class.php
@@ -2535,7 +2535,7 @@ class lessc_parser {
 			// whitespace after the operator for it to be an expression
 			$needWhite = $whiteBefore && !$this->inParens;
 
-			if ($this->match(self::$operatorString.($needWhite ? '\s' : ''), $m) && self::$precedence[$m[1]] >= $minP) {
+			if ($this->matching(self::$operatorString.($needWhite ? '\s' : ''), $m) && self::$precedence[$m[1]] >= $minP) {
 				if (!$this->inParens && isset($this->env->currentProperty) && $m[1] == "/" && empty($this->env->supressedDivision)) {
 					foreach (self::$supressDivisionProps as $pattern) {
 						if (preg_match($pattern, $this->env->currentProperty)) {
@@ -2662,7 +2662,7 @@ class lessc_parser {
 		}
 
 		// css hack: \0
-		if ($this->literal('\\') && $this->match('([0-9]+)', $m)) {
+		if ($this->literal('\\') && $this->matching('([0-9]+)', $m)) {
 			$value = array('keyword', '\\'.$m[1]);
 			return true;
 		} else {
@@ -2766,7 +2766,7 @@ class lessc_parser {
 		$nestingLevel = 0;
 
 		$content = array();
-		while ($this->match($patt, $m, false)) {
+		while ($this->matching($patt, $m, false)) {
 			if (!empty($m[1])) {
 				$content[] = $m[1];
 				if ($nestingOpen) {
@@ -2835,7 +2835,7 @@ class lessc_parser {
 		$oldWhite = $this->eatWhiteDefault;
 		$this->eatWhiteDefault = false;
 
-		while ($this->match($patt, $m, false)) {
+		while ($this->matching($patt, $m, false)) {
 			$content[] = $m[1];
 			if ($m[2] == "@{") {
 				$this->count -= strlen($m[2]);
@@ -2894,7 +2894,7 @@ class lessc_parser {
 			if (!ctype_digit($char) && $char != ".") return false;
 		}
 
-		if ($this->match('([0-9]+(?:\.[0-9]*)?|\.[0-9]+)([%a-zA-Z]+)?', $m)) {
+		if ($this->matching('([0-9]+(?:\.[0-9]*)?|\.[0-9]+)([%a-zA-Z]+)?', $m)) {
 			$unit = array("number", $m[1], empty($m[2]) ? "" : $m[2]);
 			return true;
 		}
@@ -2903,7 +2903,7 @@ class lessc_parser {
 
 	// a # color
 	protected function color(&$out) {
-		if ($this->match('(#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{3}))', $m)) {
+		if ($this->matching('(#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{3}))', $m)) {
 			if (strlen($m[1]) > 7) {
 				$out = array("string", "", array($m[1]));
 			} else {
@@ -3066,7 +3066,7 @@ class lessc_parser {
 					break; // get out early
 				}
 
-				if ($this->match('\s+', $m)) {
+				if ($this->matching('\s+', $m)) {
 					$attrParts[] = " ";
 					continue;
 				}
@@ -3093,7 +3093,7 @@ class lessc_parser {
 				}
 
 				// operator, handles attr namespace too
-				if ($this->match('[|-~\$\*\^=]+', $m)) {
+				if ($this->matching('[|-~\$\*\^=]+', $m)) {
 					$attrParts[] = $m[0];
 					continue;
 				}
@@ -3133,7 +3133,7 @@ class lessc_parser {
 		$this->eatWhiteDefault = false;
 
 		while (true) {
-			if ($this->match('(['.$chars.'0-9]['.$chars.']*)', $m)) {
+			if ($this->matching('(['.$chars.'0-9]['.$chars.']*)', $m)) {
 				$parts[] = $m[1];
 				if ($simple) break;
 
@@ -3184,7 +3184,7 @@ class lessc_parser {
 	protected function func(&$func) {
 		$s = $this->seek();
 
-		if ($this->match('(%|[\w\-_][\w\-_:\.]+|[\w_])', $m) && $this->literal('(')) {
+		if ($this->matching('(%|[\w\-_][\w\-_:\.]+|[\w_])', $m) && $this->literal('(')) {
 			$fname = $m[1];
 
 			$sPreArgs = $this->seek();
@@ -3253,7 +3253,7 @@ class lessc_parser {
 
 	// consume a keyword
 	protected function keyword(&$word) {
-		if ($this->match('([\w_\-\*!"][\w\-_"]*)', $m)) {
+		if ($this->matching('([\w_\-\*!"][\w\-_"]*)', $m)) {
 			$word = $m[1];
 			return true;
 		}
@@ -3350,7 +3350,7 @@ class lessc_parser {
 			self::$literalCache[$what] = lessc::preg_quote($what);
 		}
 
-		return $this->match(self::$literalCache[$what], $m, $eatWhitespace);
+		return $this->matching(self::$literalCache[$what], $m, $eatWhitespace);
 	}
 
 	protected function genericList(&$out, $parseItem, $delim="", $flatten=true) {
@@ -3387,14 +3387,14 @@ class lessc_parser {
 		} else {
 			$validChars = $allowNewline ? "." : "[^\n]";
 		}
-		if (!$this->match('('.$validChars.'*?)'.lessc::preg_quote($what), $m, !$until)) return false;
+		if (!$this->matching('('.$validChars.'*?)'.lessc::preg_quote($what), $m, !$until)) return false;
 		if ($until) $this->count -= strlen($what); // give back $what
 		$out = $m[1];
 		return true;
 	}
 
 	// try to match something on head of buffer
-	protected function match($regex, &$out, $eatWhitespace = null) {
+	protected function matching($regex, &$out, $eatWhitespace = null) {
 		if ($eatWhitespace === null) $eatWhitespace = $this->eatWhiteDefault;
 
 		$r = '/'.$regex.($eatWhitespace && !$this->writeComments ? '\s*' : '').'/Ais';
@@ -3420,7 +3420,7 @@ class lessc_parser {
 			}
 			return $gotWhite;
 		} else {
-			$this->match("", $m);
+			$this->matching("", $m);
 			return strlen($m[0]) > 0;
 		}
 	}


### PR DESCRIPTION
This pull request adds support for PHP 8.0+ by making the following two changes:
- Changing the name of the `match` function to `matching`
- Changing the curly brackets (`{}`) for offset access to square brackets (`[]`)

See https://www.php.net/manual/en/migration80.incompatible.php for details.

Fixes #458.