### PR TITLE
Fix a zip error

### DIFF
--- a/app/kod/archiveLib/pclzip.class.php
+++ b/app/kod/archiveLib/pclzip.class.php
@@ -2700,7 +2700,10 @@
         }
 
         // ----- Read the file content
-        $v_content = @fread($v_file, $p_header['size']);
+        $v_content = '';
+        if ($p_header['size'] > 0) {
+            $v_content = @fread($v_file, $p_header['size']);
+        }
 
         // ----- Close the file
         @fclose($v_file);


### PR DESCRIPTION
Fix Fatal error:  Uncaught ValueError: fread(): Argument #2 ($length) must be greater than 0 in /app/kod/archiveLib/pclzip.class.php:2704