### PR TITLE
Fix a image prorate error

### DIFF
--- a/app/kod/ImageThumb.class.php
+++ b/app/kod/ImageThumb.class.php
@@ -90,6 +90,9 @@ class ImageThumb {
 	} 
 	// 生成按比例缩放的缩图
 	function prorate($toFile, $toW, $toH){
+		if(!$this->im){
+			return false;
+		}
 		$toWH = $toW / $toH;
 		$srcWH = $this->srcW / $this->srcH;
 		if ($toWH<=$srcWH) {


### PR DESCRIPTION
Some svg images can cause this problem.

PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string / string in /kod/app/kod/ImageThumb.class.php:94 Stack trace:
#0 /kod/app/controller/explorer.class.php(1100): ImageThumb->prorate('/kod/data...', 250, 250) #1 /kod/app/core/Application.class.php(64): explorer->image() #2 /kod/app/core/Application.class.php(104): Application->appRun('explorer', 'image') #3 /kod/index.php(114): Application->run()
#4 {main}
  thrown in /kod/app/kod/ImageThumb.class.php on line 94